### PR TITLE
Add payment link disable profile

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -37,12 +37,8 @@ export function Navbar() {
                 Events
             </a>
             <div>
-                {isSignedIn ? (
+                {isSignedIn && (
                     <a href="/profile" className="navbar-link">
-                        Profile
-                    </a>
-                ) : (
-                    <a href="/" className="navbar-link">
                         Profile
                     </a>
                 )}

--- a/src/pages/Dashboard/Dashboard.css
+++ b/src/pages/Dashboard/Dashboard.css
@@ -14,6 +14,22 @@ body {
   gap: 2rem;
 }
 
+.dashboard-top-banner {
+  text-align: center;
+  background-color: #fff;
+  color: var(--pmc-dark-blue);
+  padding: 20px 10px;
+  border-radius: 20px;
+}
+
+.dashboard-top-banner a {
+  text-decoration: underline;
+}
+
+.dashboard-top-banner a:visited {
+  color: var(--pmc-dark-blue)
+}
+
 .dashboard-container {
   width: 100%;
 }

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "../../providers/Auth/AuthProvider";
 import { EventCard } from "../../components/Event/EventCard";
 
 export default function Dashboard() {
-  const { currentUser, isSignedIn } = useAuth();
+  const { currentUser, userData, isSignedIn } = useAuth();
   const [allEvents, setAllEvents] = useState<eventType[]>([]);
 
     async function dashboardComponents() {
@@ -38,6 +38,15 @@ export default function Dashboard() {
   return (
     <div className="dashboard">
       <div className={"dashboard-container"}>
+        {userData && !userData.paymentVerified && (
+          <p className="dashboard-top-banner">
+            We've noticed you have signed up as a member, 
+            but your payment is not verified. If you haven't paid, 
+            please visit our <a href="https://ubc-pmc.square.site" 
+            target="_blank">checkout page</a>. If you've paid already, 
+            we will notify you when we've verified your payment.
+          </p>
+        )}
         <div className="dashboard-header">
           <h2>Upcoming Events</h2>
           <h4 className={"welcome-message"}>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -44,7 +44,8 @@ export default function Dashboard() {
             but your payment is not verified. If you haven't paid, 
             please visit our <a href="https://ubc-pmc.square.site" 
             target="_blank">checkout page</a>. If you've paid already, 
-            we will notify you when we've verified your payment.
+            we will notify you when we've verified your payment. Your 
+            account will be activated once you are verified.
           </p>
         )}
         <div className="dashboard-header">

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -12,10 +12,12 @@ import { useState } from "react";
 import GoogleLogo from "../../assets/google.svg";
 import PMCLogo from "../../assets/pmclogo.svg";
 import Onboarding from "../../components/OnboardingForm/Onboarding";
+import { useAuth } from "../../providers/Auth/AuthProvider";
 
 export default function Login() {
   const [onboarding, setOnboarding] = useState<boolean>(false);
   const navigateTo = useNavigate();
+  const { logout } = useAuth();
 
   async function googleLogin() {
     try {
@@ -75,7 +77,10 @@ export default function Login() {
               </button>
               <button
                 className="login-continue"
-                onClick={() => navigateTo("/dashboard")}
+                onClick={async () => {
+                  navigateTo("/dashboard")
+                  await logout()
+                }}
               >
                 Continue as a non-member
               </button>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -12,12 +12,10 @@ import { useState } from "react";
 import GoogleLogo from "../../assets/google.svg";
 import PMCLogo from "../../assets/pmclogo.svg";
 import Onboarding from "../../components/OnboardingForm/Onboarding";
-import { useAuth } from "../../providers/Auth/AuthProvider";
 
 export default function Login() {
   const [onboarding, setOnboarding] = useState<boolean>(false);
   const navigateTo = useNavigate();
-  const { logout } = useAuth();
 
   async function googleLogin() {
     try {
@@ -77,10 +75,7 @@ export default function Login() {
               </button>
               <button
                 className="login-continue"
-                onClick={async () => {
-                  navigateTo("/dashboard")
-                  await logout()
-                }}
+                onClick={() => navigateTo("/dashboard")}
               >
                 Continue as a non-member
               </button>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,7 +1,7 @@
 import "./Login.css";
 import {
   GoogleAuthProvider,
-  browserLocalPersistence,
+  browserSessionPersistence,
   setPersistence,
   signInWithPopup,
   type User,
@@ -21,7 +21,7 @@ export default function Login() {
 
   async function googleLogin() {
     try {
-      setPersistence(auth, browserLocalPersistence);
+      setPersistence(auth, browserSessionPersistence);
       const authProvider = new GoogleAuthProvider();
       const signInResult = await signInWithPopup(auth, authProvider);
       const user: User = signInResult.user;

--- a/src/providers/Auth/AuthProvider.tsx
+++ b/src/providers/Auth/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
 import { auth } from "../../../firebase";
-import { User, browserLocalPersistence, setPersistence } from "firebase/auth";
+import { User, browserSessionPersistence, setPersistence } from "firebase/auth";
 import { AuthContextType, AuthProviderProps } from "./types";
 import { userDocument } from "../../types/api";
 import AuthContext from "./AuthContext";
@@ -25,7 +25,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const setAuthPersistence = async () => {
       try {
-        await setPersistence(auth, browserLocalPersistence);
+        await setPersistence(auth, browserSessionPersistence);
         console.log("Persistence set to local");
       } catch (error) {
         console.error("Failed to set persistence:", error);


### PR DESCRIPTION
Found an edge case where users fill out onboarding info but don't pay. In that case, users cannot access the checkout page anymore.

Fix:
- Added a banner in dashboard to lead them back to the checkout page.

Additional improvement:
- Switch authentication persistence from local storage to session storage
- Disable profile for users not signed in 