### PR TITLE
Fixed date/time parsing in front-end

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@stripe/stripe-js": "^4.3.0",
         "@types/auth0": "^3.3.10",
         "firebase": "^10.12.3",
+        "moment": "^2.30.1",
         "react": "^18.3.1",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.52.1",
@@ -3666,6 +3667,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@stripe/stripe-js": "^4.3.0",
     "@types/auth0": "^3.3.10",
     "firebase": "^10.12.3",
+    "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.52.1",

--- a/src/pages/Dashboard/Event.tsx
+++ b/src/pages/Dashboard/Event.tsx
@@ -74,7 +74,7 @@ const Event: React.FC = () => {
                                 <div className="icon"><CiCalendar/></div>
                                 <div className="text-container">
                                     {/* TODO: Use moment. Date string will be (YYYY-MM-DD)*/}
-                                    <h3>{moment(event.date).format("dddd, MMMM D")}</h3> 
+                                    <h3>{moment(event.date).format("ddd, MMMM D")}</h3> 
                                     {/* TODO: Update to parse time. Time string will be (Thh:mm:ss) */}
                                     <h4>{toTimeString(event.start_time, event.end_time)}</h4>
                                 </div>

--- a/src/pages/Dashboard/Event.tsx
+++ b/src/pages/Dashboard/Event.tsx
@@ -73,9 +73,9 @@ const Event: React.FC = () => {
                             <div className="icon-text">
                                 <div className="icon"><CiCalendar/></div>
                                 <div className="text-container">
-                                    {/* TODO: Use moment. Date string will be (YYYY-MM-DD)*/}
+                                    {/* Will display date as "Sun, December 1" or "Sat, November 30" */}
                                     <h3>{moment(event.date).format("ddd, MMMM D")}</h3> 
-                                    {/* TODO: Update to parse time. Time string will be (Thh:mm:ss) */}
+                                    {/* Displays time in 24 hours as hh:mm - hh:mm*/}
                                     <h4>{toTimeString(event.start_time, event.end_time)}</h4>
                                 </div>
                             </div>

--- a/src/pages/Dashboard/Event.tsx
+++ b/src/pages/Dashboard/Event.tsx
@@ -7,6 +7,7 @@ import {EventRegistrationModal} from "../../components/Event/EventRegistrationMo
 import {CiCalendar, CiLocationOn} from "react-icons/ci";
 import {MdOutlinePeopleAlt} from "react-icons/md";
 import {FaDollarSign} from "react-icons/fa6";
+import moment from 'moment';
 
 const Event: React.FC = () => {
     const {isSignedIn} = useAuth();
@@ -18,7 +19,6 @@ const Event: React.FC = () => {
     if (event) {
         isEventFull = event.maxAttendee !== null && event.attendee_Ids?.length >= event.maxAttendee;
     }
-
 
     async function fetchEvent() {
         try {
@@ -36,15 +36,22 @@ const Event: React.FC = () => {
                 throw new Error("Network response was not ok");
             }
             const data: eventType = await response.json();
-            setEvent({
-                ...data,
-                date: new Date(data.date),
-            });
+            setEvent(data)
         } catch (error) {
             console.error("Error fetching event:", error);
         } finally {
             setLoading(false);
         }
+    }
+
+    // time_string = Thh:mm:ss
+    // return hh:mm - hh:mm
+    function toTimeString(start_time: string, end_time: string): string {
+        const time_format: string = "HH:mm";
+        // only works with a date string provided. The format won't display the date only the time.
+        const start = moment(`01-01-2001 ${start_time}`).format(time_format) 
+        const end = moment(`01-01-2001 ${end_time}`).format(time_format) 
+        return start + " - " + end
     }
 
     useEffect(() => {
@@ -66,8 +73,10 @@ const Event: React.FC = () => {
                             <div className="icon-text">
                                 <div className="icon"><CiCalendar/></div>
                                 <div className="text-container">
-                                    <h3>{event.date.toDateString()}</h3>
-                                    <h4>No time available yet</h4>
+                                    {/* TODO: Use moment. Date string will be (YYYY-MM-DD)*/}
+                                    <h3>{moment(event.date).format("dddd, MMMM D")}</h3> 
+                                    {/* TODO: Update to parse time. Time string will be (Thh:mm:ss) */}
+                                    <h4>{toTimeString(event.start_time, event.end_time)}</h4>
                                 </div>
                             </div>
                             <div className="icon-text">

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -32,6 +32,8 @@ type eventType = {
   event_Id: string;
   name: string;
   date: Date;
+  start_time: string;
+  end_time: string;
   location: string;
   description: string;
   media: string[];


### PR DESCRIPTION
## Description
What changes does this PR include? Is there anything that affects other features that people should be aware of?
- Installed momentjs
- Updated event type to include start_time and end_time.
- Updated date property in event type to a string
- momentjs will parse date/times properly on the frontend

## Before and After
Screenshots/videos of the changes:
Before
![image](https://github.com/user-attachments/assets/a5fd3798-7e9f-4f97-b5df-09c658d23f44)

After
![image](https://github.com/user-attachments/assets/51d61bb3-60a7-43f7-8cbb-1a9f4167658e)

## Checklist
- [x] This code builds and runs
- [ ] I've added feature flags where necessary
- [ ] All public classes and methods are documented, as well as hard-to-understand areas of the code
- [ ] I've verified that this is accurate to the feature's design
- [ ] Self-review done
